### PR TITLE
Add Make_torrent shell script

### DIFF
--- a/Make_Torrent/Make_torrent.sh
+++ b/Make_Torrent/Make_torrent.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Simple wrapper to create a torrent file using ctorrent with a fixed tracker.
+# Usage: ./Make_torrent.sh <path>
+
+set -euo pipefail
+
+# Ensure ctorrent is installed; install if missing (Debian 12 default)
+if ! command -v ctorrent >/dev/null 2>&1; then
+    echo "ctorrent not found, installing..."
+    sudo apt-get update -y
+    sudo apt-get install -y ctorrent
+fi
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <path>"
+    exit 1
+fi
+
+target="${1%/}"
+
+if [[ ! -e "$target" ]]; then
+    echo "Error: path '$target' does not exist" >&2
+    exit 1
+fi
+
+ctorrent -t -p -u "https://tracker.m-team.cc/" -s "${target}.torrent" "$target"

--- a/Make_Torrent/README.md
+++ b/Make_Torrent/README.md
@@ -1,0 +1,18 @@
+# Make_Torrent
+
+Directory for torrent-related scripts.
+
+`Make_torrent.sh` ensures the `ctorrent` package is installed (using `apt` on
+Debian 12) before creating a torrent file with `ctorrent`.
+
+Usage:
+
+```bash
+./Make_torrent.sh /path/to/file_or_directory
+```
+
+The script invokes:
+
+```bash
+ctorrent -t -p -u "https://tracker.m-team.cc/" -s "/path/to/file_or_directory.torrent" /path/to/file_or_directory
+```


### PR DESCRIPTION
## Summary
- add Make_torrent.sh script to generate torrent files using ctorrent with m-team tracker
- ensure `ctorrent` is installed, installing via apt if missing

## Testing
- `bash -n Make_Torrent/Make_torrent.sh`
- `bash -n snell/install_snell.sh`


------
https://chatgpt.com/codex/tasks/task_e_689dbe54dd80832694dcf0085ea677e1